### PR TITLE
Make Keras aware of PhasedLSTM custom layer.

### DIFF
--- a/examples/random_example.py
+++ b/examples/random_example.py
@@ -1,6 +1,6 @@
 import numpy as np
 from keras.layers import LSTM
-from keras.models import Sequential
+from keras.models import Sequential, load_model
 
 from phased_lstm_keras.PhasedLSTM import PhasedLSTM
 
@@ -11,13 +11,17 @@ def main():
 
     model_lstm = Sequential()
     model_lstm.add(LSTM(10, input_shape=(100, 2)))
-    model_lstm.summary()
     model_lstm.compile('rmsprop', 'mse')
+    model_lstm.save('model_lstm.h5')
+    model_lstm = load_model('model_lstm.h5')
+    model_lstm.summary()
 
     model_plstm = Sequential()
     model_plstm.add(PhasedLSTM(10, input_shape=(100, 2)))
-    model_plstm.summary()
     model_plstm.compile('rmsprop', 'mse')
+    model_plstm.save('model_plstm.h5')
+    model_plstm = load_model('model_plstm.h5')
+    model_plstm.summary()
 
     model_lstm.fit(X, Y)
     model_plstm.fit(X, Y)

--- a/phased_lstm_keras/PhasedLSTM.py
+++ b/phased_lstm_keras/PhasedLSTM.py
@@ -10,6 +10,7 @@ from keras import constraints
 from keras.engine import InputSpec
 from keras.legacy import interfaces
 from keras.layers import Recurrent
+from keras.utils.generic_utils import get_custom_objects
 
 def _time_distributed_dense(x, w, b=None, dropout=None,
                             input_dim=None, output_dim=None,
@@ -395,3 +396,6 @@ class PhasedLSTM(Recurrent):
                   'recurrent_dropout': self.recurrent_dropout}
         base_config = super(PhasedLSTM, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
+
+
+get_custom_objects().update({'PhasedLSTM': PhasedLSTM})


### PR DESCRIPTION
We need to use `custom_objects` when loading a model containing a PLSTM layer:
`model_plstm = load_model('model_plstm.h5', custom_objects={'PhasedLSTM': PhasedLSTM})`

This commit make everything simpler, no need to mess with `custom_objects` anymore:
`model_plstm = load_model('model_plstm.h5')`

I modified `examples/random_example.py` to provide a simple example of saving/loading models.

Tested on Keras 2.0.3, works fine.